### PR TITLE
Install script message clarification

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,6 +218,8 @@ EOF
     fi
 fi
 
+IPADDR=$(hostname -I | awk '{$1=$1};1')
+
 msg ':: Complete'
 echo
-msg 'Ajenti will be listening at HTTP port 8000\nLog in with your root password or another OS user'
+msg "Ajenti will be listening at https://$IPADDR:8000\nLog in with your root password or another OS user"


### PR DESCRIPTION
Changed message to reflect need to use HTTPS instead of HTTP, due to the self-signed certificate installed with Ajenti. Added host IP address to message. 

Without it, users would (incorrectly) assume that they could access their installation at http://hostname:8000, which does not work.

